### PR TITLE
fix: use new routeOptions object. No more deprecation warnings

### DIFF
--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -169,8 +169,8 @@ const FastifySentry = fastifyPlugin(async function FastifySentry(fastify, option
         })
 
         fastify.addHook('onRequest', function (req, rep, done) {
-            const method = req.routerMethod ?? req.method
-            const path = req.routerPath ?? req.url
+            const method = req.routeOptions.method ?? req.method;
+            const path = req.routeOptions.url ?? req.url;
             const tx = Sentry.startTransaction({
                 op: `${method} ${path}`,
                 name: path,

--- a/lib/plugin.ts
+++ b/lib/plugin.ts
@@ -169,8 +169,8 @@ const FastifySentry = fastifyPlugin(async function FastifySentry(fastify, option
         })
 
         fastify.addHook('onRequest', function (req, rep, done) {
-            const method = req.routeOptions.method ?? req.method;
-            const path = req.routeOptions.url ?? req.url;
+            const method = req.routeOptions?.method ?? req.routerMethod ?? req.method;
+            const path = req.routeOptions?.url ?? req.routerPath ?? req.url;
             const tx = Sentry.startTransaction({
                 op: `${method} ${path}`,
                 name: path,


### PR DESCRIPTION
This fixes deprecation warnings because Fastify moved these into their own object, routeOptions. 